### PR TITLE
fix issue in lengthReq

### DIFF
--- a/src/memory/client/MemoryBrowser.tsx
+++ b/src/memory/client/MemoryBrowser.tsx
@@ -142,7 +142,7 @@ export class MemoryBrowser extends React.Component<Props, State> {
             size={6}
             title="Number of bytes to fetch, in decimal or hexadecimal"
             defaultValue={this.lengthReq}
-            onChange={(event) => (this.addressReq = event.target.value)}
+            onChange={(event) => (this.lengthReq = event.target.value)}
           />
         </div>
         <div className="input-group">


### PR DESCRIPTION
Hi @jonahgraham ,
I think this is an issue with data in "Length" box of Memory Browser.
Currently, the size of memory to be viewed is the value of "Location" box (address) but not "Length" box.
Could you please help to check it?