### PR TITLE
Implement multiple memory browser webview

### DIFF
--- a/src/memory/server/MemoryServer.ts
+++ b/src/memory/server/MemoryServer.ts
@@ -45,18 +45,18 @@ export class MemoryServer {
         });
 
         newPanel.webview.html = `
-                 <html>
-                     <head>
-                         <meta charset="utf-8">
-                         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-                     </head>
-                     <body>
-                         <div id="app"></div>
-                         ${this.loadScript(context, 'out/vendor.js')}
-                         ${this.loadScript(context, 'out/MemoryBrowser.js')}
-                     </body>
-                 </html>
-             `;
+            <html>
+                <head>
+                    <meta charset="utf-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+                </head>
+                <body>
+                    <div id="app"></div>
+                    ${this.loadScript(context, 'out/vendor.js')}
+                    ${this.loadScript(context, 'out/MemoryBrowser.js')}
+                </body>
+            </html>
+        `;
         //
 
         // Reset when panel is disposed

--- a/src/memory/server/MemoryServer.ts
+++ b/src/memory/server/MemoryServer.ts
@@ -13,11 +13,10 @@ import { ClientRequest, ServerResponse, ReadMemory } from '../common/messages';
 import { MemoryContents } from 'cdt-gdb-adapter';
 
 export class MemoryServer {
-
     constructor(context: vscode.ExtensionContext) {
         context.subscriptions.push(
             vscode.commands.registerCommand('cdt.gdb.memory.open', () =>
-                this.openPanel(context);
+                this.openPanel(context)
             )
         );
     }
@@ -62,8 +61,10 @@ export class MemoryServer {
             .toString()}"></script>`;
     }
 
-    private onDidReceiveMessage(request: ClientRequest,
-        panel: vscode.WebviewPanel) {
+    private onDidReceiveMessage(
+        request: ClientRequest,
+        panel: vscode.WebviewPanel
+    ) {
         switch (request.command) {
             case 'ReadMemory':
                 this.handleReadMemory(request, panel);
@@ -83,8 +84,10 @@ export class MemoryServer {
         }
     }
 
-    private async handleReadMemory(request: ReadMemory.Request,
-        panel: vscode.WebviewPanel) {
+    private async handleReadMemory(
+        request: ReadMemory.Request,
+        panel: vscode.WebviewPanel
+    ) {
         const session = vscode.debug.activeDebugSession;
         if (session) {
             try {

--- a/src/memory/server/MemoryServer.ts
+++ b/src/memory/server/MemoryServer.ts
@@ -17,18 +17,15 @@ export class MemoryServer {
 
     constructor(context: vscode.ExtensionContext) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('cdt.gdb.memory.open', () => {
-                if (this.panel) {
-                    this.panel.reveal();
-                } else {
-                    this.openPanel(context);
-                }
-            })
+            vscode.commands.registerCommand('cdt.gdb.memory.open', () =>
+                this.openPanel(context)
+            )
         );
     }
 
     private openPanel(context: vscode.ExtensionContext) {
-        this.panel = vscode.window.createWebviewPanel(
+        let newPanel: vscode.WebviewPanel;
+        newPanel = vscode.window.createWebviewPanel(
             'cdtMemoryBrowser',
             'Memory Browser',
             vscode.ViewColumn.One,
@@ -40,29 +37,32 @@ export class MemoryServer {
                 retainContextWhenHidden: true,
             }
         );
-        context.subscriptions.push(this.panel);
+        context.subscriptions.push(newPanel);
 
-        this.panel.webview.onDidReceiveMessage((message) =>
-            this.onDidReceiveMessage(message)
-        );
+        newPanel.webview.onDidReceiveMessage((message) => {
+            this.panel = newPanel;
+            this.onDidReceiveMessage(message);
+        });
 
-        this.panel.webview.html = `
-            <html>
-                <head>
-                    <meta charset="utf-8">
-                    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-                </head>
-                <body>
-                    <div id="app"></div>
-                    ${this.loadScript(context, 'out/vendor.js')}
-                    ${this.loadScript(context, 'out/MemoryBrowser.js')}
-                </body>
-            </html>
-        `;
+        newPanel.webview.html = `
+                 <html>
+                     <head>
+                         <meta charset="utf-8">
+                         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+                     </head>
+                     <body>
+                         <div id="app"></div>
+                         ${this.loadScript(context, 'out/vendor.js')}
+                         ${this.loadScript(context, 'out/MemoryBrowser.js')}
+                     </body>
+                 </html>
+             `;
+        //
 
         // Reset when panel is disposed
-        this.panel.onDidDispose(
+        newPanel.onDidDispose(
             () => {
+                this.panel = newPanel;
                 this.panel = undefined;
             },
             null,

--- a/src/memory/server/MemoryServer.ts
+++ b/src/memory/server/MemoryServer.ts
@@ -57,7 +57,6 @@ export class MemoryServer {
                 </body>
             </html>
         `;
-        //
 
         // Reset when panel is disposed
         newPanel.onDidDispose(


### PR DESCRIPTION
Currently, Memory Browser tab can load data in the last tab if opening multiple tabs of its. (the other tab opened first is Empty). When the second tab is opened, the first tab is overwritten by the second. That makes the instance of the first tab lost. ->When user switches to the first tab and click "Go", Server can get memory data but the result response to Client is incorrect. Data cannot be sent to Client → Data in the first tab is empty.

=>So the solution is: Create a new object `vscode.WebviewPanel`  for each context call `openPanel` -> Can use multiple Memory Browser views.