### PR TITLE
Adding the ability to configure serial port output to the debug console

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,6 +339,44 @@
                   "automaticallyKillServer": {
                     "type": "boolean",
                     "description": "Automatically kill the launched server when client issues a disconnect (default: true)"
+                  },
+                  "uartSerialPort": {
+                    "type": "string",
+                    "description": "Path to the serial port connected to the UART on the board."
+                  },
+                  "uartSocketPort": {
+                    "type": "string",
+                    "description": "Target TCP port on the host machine to attach socket to print UART output (defaults to 3456)",
+                    "default": "3456"
+                  },
+                  "baudRate": {
+                    "type": "number",
+                    "description": "Baud Rate (in bits/s) of the serial port to be opened (defaults to 115200).",
+                    "default": 115200
+                  },
+                  "characterSize": {
+                    "type": "number",
+                    "enum": [5, 6, 7, 8],
+                    "description": "The number of bits in each character of data sent across the serial line (defaults to 8).",
+                    "default": 8
+                  },
+                  "parity": {
+                    "type": "string",
+                    "enum": ["none", "odd", "even", "mark", "space"],
+                    "description": "The type of parity check enabled with the transmitted data (defaults to \"none\" - no parity bit sent)",
+                    "default": "none"
+                  },
+                  "stopBits": {
+                    "type": "number",
+                    "enum": [1, 1.5, 2],
+                    "description": "The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream (defaults to 1).",
+                    "default": 1
+                  },
+                  "handshakingMethod": {
+                    "type": "string",
+                    "enum": ["none", "XON/XOFF", "RTS/CTS"],
+                    "description": "The handshaking method used for flow control across the serial line (defaults to \"none\" - no handshaking)",
+                    "default": "none"
                   }
                 }
               }
@@ -524,7 +562,9 @@
     "cdt-amalgamator": "^0.0.11",
     "cdt-gdb-adapter": "^0.0.25",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "serialport": "11.0.0",
+    "@types/serialport": "8.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -340,43 +340,77 @@
                     "type": "boolean",
                     "description": "Automatically kill the launched server when client issues a disconnect (default: true)"
                   },
-                  "uartSerialPort": {
-                    "type": "string",
-                    "description": "Path to the serial port connected to the UART on the board."
-                  },
-                  "uartSocketPort": {
-                    "type": "string",
-                    "description": "Target TCP port on the host machine to attach socket to print UART output (defaults to 3456)",
-                    "default": "3456"
-                  },
-                  "baudRate": {
-                    "type": "number",
-                    "description": "Baud Rate (in bits/s) of the serial port to be opened (defaults to 115200).",
-                    "default": 115200
-                  },
-                  "characterSize": {
-                    "type": "number",
-                    "enum": [5, 6, 7, 8],
-                    "description": "The number of bits in each character of data sent across the serial line (defaults to 8).",
-                    "default": 8
-                  },
-                  "parity": {
-                    "type": "string",
-                    "enum": ["none", "odd", "even", "mark", "space"],
-                    "description": "The type of parity check enabled with the transmitted data (defaults to \"none\" - no parity bit sent)",
-                    "default": "none"
-                  },
-                  "stopBits": {
-                    "type": "number",
-                    "enum": [1, 1.5, 2],
-                    "description": "The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream (defaults to 1).",
-                    "default": 1
-                  },
-                  "handshakingMethod": {
-                    "type": "string",
-                    "enum": ["none", "XON/XOFF", "RTS/CTS"],
-                    "description": "The handshaking method used for flow control across the serial line (defaults to \"none\" - no handshaking)",
-                    "default": "none"
+                  "uart": {
+                    "type": "object",
+                    "description": "Settings related to displaying UART output in the debug console",
+                    "properties": {
+                      "serialPort": {
+                        "type": "string",
+                        "description": "Path to the serial port connected to the UART on the board."
+                      },
+                      "socketPort": {
+                        "type": "string",
+                        "description": "Target TCP port on the host machine to attach socket to print UART output (defaults to 3456)",
+                        "default": "3456"
+                      },
+                      "baudRate": {
+                        "type": "number",
+                        "description": "Baud Rate (in bits/s) of the serial port to be opened (defaults to 115200).",
+                        "default": 115200
+                      },
+                      "characterSize": {
+                        "type": "number",
+                        "enum": [
+                          5,
+                          6,
+                          7,
+                          8
+                        ],
+                        "description": "The number of bits in each character of data sent across the serial line (defaults to 8).",
+                        "default": 8
+                      },
+                      "parity": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "odd",
+                          "even",
+                          "mark",
+                          "space"
+                        ],
+                        "description": "The type of parity check enabled with the transmitted data (defaults to \"none\" - no parity bit sent)",
+                        "default": "none"
+                      },
+                      "stopBits": {
+                        "type": "number",
+                        "enum": [
+                          1,
+                          1.5,
+                          2
+                        ],
+                        "description": "The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream (defaults to 1).",
+                        "default": 1
+                      },
+                      "handshakingMethod": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "XON/XOFF",
+                          "RTS/CTS"
+                        ],
+                        "description": "The handshaking method used for flow control across the serial line (defaults to \"none\" - no handshaking)",
+                        "default": "none"
+                      },
+                      "eolCharacter": {
+                        "type": "string",
+                        "enum": [
+                            "LF",
+                            "CRLF"
+                        ],
+                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"LF\").",
+                        "default": "LF"
+                      }
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -407,8 +407,8 @@
                             "LF",
                             "CRLF"
                         ],
-                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"CRLF\").",
-                        "default": "CRLF"
+                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"LF\").",
+                        "default": "LF"
                       }
                     }
                   }
@@ -590,8 +590,8 @@
                             "LF",
                             "CRLF"
                         ],
-                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"CRLF\").",
-                        "default": "CRLF"
+                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"LF\").",
+                        "default": "LF"
                       }
                     }
                   }

--- a/package.json
+++ b/package.json
@@ -404,8 +404,8 @@
                       "eolCharacter": {
                         "type": "string",
                         "enum": [
-                            "LF",
-                            "CRLF"
+                          "LF",
+                          "CRLF"
                         ],
                         "description": "The EOL character used to parse the UART output line-by-line (defaults to \"LF\").",
                         "default": "LF"
@@ -587,8 +587,8 @@
                       "eolCharacter": {
                         "type": "string",
                         "enum": [
-                            "LF",
-                            "CRLF"
+                          "LF",
+                          "CRLF"
                         ],
                         "description": "The EOL character used to parse the UART output line-by-line (defaults to \"LF\").",
                         "default": "LF"

--- a/package.json
+++ b/package.json
@@ -407,8 +407,8 @@
                             "LF",
                             "CRLF"
                         ],
-                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"LF\").",
-                        "default": "LF"
+                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"CRLF\").",
+                        "default": "CRLF"
                       }
                     }
                   }
@@ -522,6 +522,78 @@
                     "type": "string",
                     "description": "Target port to connect to (defaults to value captured by serverPortRegExp, ignored if parameters is set)",
                     "default": "2331"
+                  },
+                  "uart": {
+                    "type": "object",
+                    "description": "Settings related to displaying UART output in the debug console",
+                    "properties": {
+                      "serialPort": {
+                        "type": "string",
+                        "description": "Path to the serial port connected to the UART on the board."
+                      },
+                      "socketPort": {
+                        "type": "string",
+                        "description": "Target TCP port on the host machine to attach socket to print UART output (defaults to 3456)",
+                        "default": "3456"
+                      },
+                      "baudRate": {
+                        "type": "number",
+                        "description": "Baud Rate (in bits/s) of the serial port to be opened (defaults to 115200).",
+                        "default": 115200
+                      },
+                      "characterSize": {
+                        "type": "number",
+                        "enum": [
+                          5,
+                          6,
+                          7,
+                          8
+                        ],
+                        "description": "The number of bits in each character of data sent across the serial line (defaults to 8).",
+                        "default": 8
+                      },
+                      "parity": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "odd",
+                          "even",
+                          "mark",
+                          "space"
+                        ],
+                        "description": "The type of parity check enabled with the transmitted data (defaults to \"none\" - no parity bit sent)",
+                        "default": "none"
+                      },
+                      "stopBits": {
+                        "type": "number",
+                        "enum": [
+                          1,
+                          1.5,
+                          2
+                        ],
+                        "description": "The number of stop bits sent to allow the receiver to detect the end of characters and resynchronize with the character stream (defaults to 1).",
+                        "default": 1
+                      },
+                      "handshakingMethod": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "XON/XOFF",
+                          "RTS/CTS"
+                        ],
+                        "description": "The handshaking method used for flow control across the serial line (defaults to \"none\" - no handshaking)",
+                        "default": "none"
+                      },
+                      "eolCharacter": {
+                        "type": "string",
+                        "enum": [
+                            "LF",
+                            "CRLF"
+                        ],
+                        "description": "The EOL character used to parse the UART output line-by-line (defaults to \"CRLF\").",
+                        "default": "CRLF"
+                      }
+                    }
                   }
                 }
               }

--- a/package.json
+++ b/package.json
@@ -596,9 +596,7 @@
     "cdt-amalgamator": "^0.0.11",
     "cdt-gdb-adapter": "^0.0.25",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "serialport": "11.0.0",
-    "@types/serialport": "8.0.2"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",


### PR DESCRIPTION
This PR introduces a set of parameters that allow us to configure a serial line in the adapter to print UART output from on-board/emulation debug to the debug console. These parameters include the TCP port to hook onto (for emulation programs outputting UART output), or the serial port on the host machine to capture UART output from. For the serial line, we also configure the baud rate, stop bits, handshaking method, etc.

This PR has a sister PR, https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/271, in the CDT-GDB-Adapter repository.