### PR TITLE
Don't include pty.node unless on Linux

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,6 +1,7 @@
 // @ts-check
 const esbuild = require('esbuild');
 const path = require('node:path');
+const os = require('node:os');
 const { sassPlugin } = require('esbuild-sass-plugin');
 
 /** @typedef {import('esbuild').BuildOptions} BuildOptions */
@@ -48,7 +49,7 @@ const configurations = [
             path.join(debugAdapterRoot, 'debugTargetAdapter.js'),
         ],
         outdir: path.join(__dirname, 'dist'),
-        external: ['process'], // Workaround pending https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/288
+        external: os.platform() !== 'linux' ? ['*/pty.node'] : undefined,
         loader: { '.node': 'copy' },
         format: 'cjs',
         platform: 'node',


### PR DESCRIPTION
The CDT GDB Adapter's [`install.js`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/33b2f35173f67563ebb1d42a6cd4aaf7484cb90c/install.js#L5) only runs the native build if the platform is Linux. That means that in other cases, there will be no `pty.node` file created, and we should not try to include it any bundle generated on a different platform. Alternatively, we could modify the adapter to run the build on other platforms, even if it is not anticipated that the code will be used.

This allows the plugin to be built smoothly on platforms other than Linux.

CC: @asimgunes