### PR TITLE
Update to adapter 0.0.30 (cwd, environment and complex vars)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,21 @@
                 "description": "Path to gdb",
                 "default": "gdb"
               },
+              "cwd": {
+                "type": "string",
+                "description": "Working directory (cwd) to use when launching gdb. Defaults to the directory of the 'program'"
+              },
+              "environment": {
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "default": {},
+                "description": "Environment variables to use when launching gdb, defined as a key-value pairs. Use null value to remove variable. For example:\n\"environment\": {\n  \"VARNAME\": \"value\",\n  \"PATH\": \"/new/item:${env:PATH}\",\n  \"REMOVEME\": null\n}",
+                "type": "object"
+              },
               "program": {
                 "type": "string",
                 "description": "Path to the program to be launched",
@@ -125,6 +140,21 @@
                 "type": "string",
                 "description": "Path to gdb",
                 "default": "gdb"
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Working directory (cwd) to use when launching gdb. Defaults to the directory of the 'program'"
+              },
+              "environment": {
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "default": {},
+                "description": "Environment variables to use when launching gdb, defined as a key-value pairs. Use null value to remove variable. For example:\n\"environment\": {\n  \"VARNAME\": \"value\",\n  \"PATH\": \"/new/item:${env:PATH}\",\n  \"REMOVEME\": null\n}",
+                "type": "object"
               },
               "program": {
                 "type": "string",
@@ -210,6 +240,21 @@
                 "type": "string",
                 "description": "Path to gdb",
                 "default": "gdb"
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Working directory (cwd) to use when launching gdb. Defaults to the directory of the 'program'"
+              },
+              "environment": {
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "default": {},
+                "description": "Environment variables to use when launching gdb, defined as a key-value pairs. Use null value to remove variable. For example:\n\"environment\": {\n  \"VARNAME\": \"value\",\n  \"PATH\": \"/new/item:${env:PATH}\",\n  \"REMOVEME\": null\n}",
+                "type": "object"
               },
               "program": {
                 "type": "string",
@@ -312,6 +357,17 @@
                     "type": "string",
                     "description": "Specifies the working directory of server (defaults to the working directory of gdb)",
                     "default": ""
+                  },
+                  "environment": {
+                    "additionalProperties": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "default": {},
+                    "description": "Environment variables to use when launching server (defaults to the environment used to launch gdb), defined as a key-value pairs. Use null value to remove variable. For example:\n\"environment\": {\n  \"VARNAME\": \"value\",\n  \"PATH\": \"/new/item:${env:PATH}\",\n  \"REMOVEME\": null\n}",
+                    "type": "object"
                   },
                   "server": {
                     "type": "string",
@@ -425,6 +481,21 @@
                 "type": "string",
                 "description": "Path to gdb",
                 "default": "gdb"
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Working directory (cwd) to use when launching gdb. Defaults to the directory of the 'program'"
+              },
+              "environment": {
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "default": {},
+                "description": "Environment variables to use when launching gdb, defined as a key-value pairs. Use null value to remove variable. For example:\n\"environment\": {\n  \"VARNAME\": \"value\",\n  \"PATH\": \"/new/item:${env:PATH}\",\n  \"REMOVEME\": null\n}",
+                "type": "object"
               },
               "program": {
                 "type": "string",
@@ -668,7 +739,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^0.0.28",
+    "cdt-gdb-adapter": "^0.0.30",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,10 +604,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^0.0.28:
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.28.tgz#6170bd6f7c2a8a94ed44b630ae545fe819027056"
-  integrity sha512-iMrGLxGL7XL6364LRUBSfIT8DMIOkOsnE7/qIQO2Th7GhsHs39vXjKOMToJVsUWU0nGspT9xkJ+xX30F7HHWUQ==
+cdt-gdb-adapter@^0.0.30:
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.30.tgz#ccefb4c7f4bc86f233584627d963b1904fdd6033"
+  integrity sha512-EDbAo5kfG06jtLh/BOViuI0CK40nlcqEYpl8+9DqpZr1dv0v64EmwZNu25OYQ5MXL1j/ohBVhO1E43FhfJIx6A==
   dependencies:
     "@vscode/debugadapter" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"


### PR DESCRIPTION
Adds support for these features in the adapter:

- setting cwd for gdb
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/306
- better handling of complex variables:
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/304
- environment variables
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/303

And the new launch.json settings needed to enable the above.

Along with a variety of bug fixes in the adapter.