### PR TITLE
Packaging updates

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,21 +1,20 @@
 // @ts-check
 const esbuild = require('esbuild');
 const path = require('node:path');
-const os = require('node:os');
 const { sassPlugin } = require('esbuild-sass-plugin');
 
 /** @typedef {import('esbuild').BuildOptions} BuildOptions */
 
 const args = process.argv.slice(2);
 const CLIWatch = args.includes('--watch');
-const CLIDevelopment = CLIWatch || args.includes('--development');
+const NoMinify = args.includes('--no-minify');
 
 /** @type {BuildOptions} */
 const commonConfig = {
     bundle: true,
     target: ['es2020'],
-    minify: !CLIDevelopment,
-    sourcemap: CLIDevelopment,
+    minify: !NoMinify,
+    sourcemap: true,
 };
 
 const srcDir = path.join(__dirname, 'src');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "homepage": "https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode#readme",
   "main": "./dist/extension",
+  "types": "./dist/extension.d.ts",
   "engines": {
     "vscode": "^1.78.0"
   },
@@ -770,6 +771,12 @@
     "CONTRIBUTING.md",
     "dist/**/*.js",
     "dist/**/*.js.map",
-    "dist/**/*.d.ts"
+    "dist/**/*.css",
+    "dist/**/*.css.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.scss"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "lib": ["es2015", "dom"],
     "jsx": "react",
     "strict": true,
+    "declaration": true,
+    "declarationMap": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
@@ -17,5 +19,5 @@
     "preserveWatchOutput": true
   },
   "references": [{ "path": "src/memory/client/tsconfig.json" }],
-  "exclude": ["**/client/*"]
+  "exclude": ["**/client/*", "**/dist/*"]
 }


### PR DESCRIPTION
Hi @jonahgraham, 

I like to discuss this update as a follow-up changes for previous work at pull-request #96.

In this update:

* Removed the "CLI development" option from build scripts, and minify and extract source map at all times.
* Removed the tsc compiler execution at build phase, leave build operation to ESBuild. Thus remove `out` folder extract all the output at `dist` folder.
* Optimised the build scripts and include ESModule format besides to CommonJS format.
* Added types decleration to build output.
* Set the CJS, ESM entry points and types decleration entry points in package.json
* Minor changes at VSIX package files (at .vscodeignore).
* Minor changes at Node package files (at package.json).

Benefits: 
* Included source map files at all times, ease the debug operation.
* Included type declarations made `cdt-gdb-vscode` easy to use as a package depedency.
* Removing tsc at the build phase do not have any side effect (as far as I observed). Besides remove the redundant/unnecessary `out` folder from the build output (Since entry points already changed to `dist` folder.)

I didnot add any script definition for triggering package publishing operation in npm registry, but, after this update, I believe we can publish cdt-gdb-vscode as an npm package and anyone could easily use cdt-gdb-vscode as a dependent package and extend behaviour.

I hope this would create a positive impact for cdt-gdb-vscode.

Kind regards.
Asim