### PR TITLE
Make linting work; Make formatting easier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/package.json
+++ b/package.json
@@ -757,6 +757,7 @@
     "esbuild": "^0.19.2",
     "esbuild-sass-plugin": "^2.13.0",
     "eslint": "^8.35.0",
+    "eslint-config-prettier": "^8.6.0",
     "event-stream": "^4.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "2.8.4",

--- a/src/memory/client/MemoryBrowser.tsx
+++ b/src/memory/client/MemoryBrowser.tsx
@@ -84,7 +84,7 @@ export class MemoryBrowser extends React.Component<Props, State> {
   private addressReq = '';
   private lengthReq = '512';
   private childReq = 0;
-  public static firstTime: boolean = true;
+  public static firstTime = true;
 
   constructor(props: Props) {
     super(props);
@@ -356,7 +356,7 @@ export class MemoryBrowser extends React.Component<Props, State> {
       MemoryBrowser.firstTime = false;
     }
     const { childrenNames } = this.state;
-    let childrenNamesList =
+    const childrenNamesList =
       childrenNames.length > 0 &&
       childrenNames.map((item, i) => {
         return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,6 +972,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@^8.6.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz#3a06a662130807e2502fc3ff8b4143d8a0658e11"
+  integrity sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
This PR does a couple of things:
 - Adds Prettier to the workspace extension recommendations.
 - Sets Prettier as the default formatter.
 - Adds the `eslint-config-prettier` ESLint plugin to the dev dependencies. Without this, the `yarn lint` script was failing.
 - Fixes a couple of pieces of lint that had slipped in.
