### PR TITLE
Include serialport bindings in package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,3 @@
 node_modules
 # don't lint build output (make sure it's set to your correct build folder name)
 dist
-out

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /node_modules/
-/out/
 /dist/
 *.vsix

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
 /node_modules/
-/out/
 /dist/
 *.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,11 +1,12 @@
-# Exclude everything
-*
-*/
-
-# Include the following:
-!images/
-!dist/
-!LICENSE
-!NOTICE
-!package.json
-!README.md
+adapter
+.gitignore
+.gitmodules
+.vscode
+dist/**/*.map
+**/*.tsbuildinfo
+package-lock.json
+README.md
+src
+tsconfig.json
+webpack.config.js
+*.code-workspace

--- a/esbuild.js
+++ b/esbuild.js
@@ -18,41 +18,15 @@ const commonConfig = {
     sourcemap: CLIDevelopment,
 };
 
-const outDir = path.join(__dirname, 'out');
-const debugAdapterRoot = path.join(
-    __dirname,
-    'node_modules',
-    'cdt-gdb-adapter',
-    'dist'
-);
+const srcDir = path.join(__dirname, 'src');
 /** @type {BuildOptions[]} */
 const configurations = [
     {
-        entryPoints: [path.join(outDir, 'extension.js')],
-        outdir: path.join(__dirname, 'dist'),
-        external: ['vscode'],
-        format: 'cjs',
-        platform: 'node',
-        ...commonConfig,
-    },
-    {
-        entryPoints: [path.join(outDir, 'memory', 'client', 'index.js')],
+        entryPoints: [path.join(srcDir, 'memory', 'client', 'index.tsx')],
         outfile: path.join(__dirname, 'dist', 'MemoryBrowser.js'),
         plugins: [sassPlugin()],
         format: 'iife',
         platform: 'browser',
-        ...commonConfig,
-    },
-    {
-        entryPoints: [
-            path.join(debugAdapterRoot, 'debugAdapter.js'),
-            path.join(debugAdapterRoot, 'debugTargetAdapter.js'),
-        ],
-        outdir: path.join(__dirname, 'dist'),
-        external: os.platform() !== 'linux' ? ['*/pty.node'] : undefined,
-        loader: { '.node': 'copy' },
-        format: 'cjs',
-        platform: 'node',
         ...commonConfig,
     },
 ];

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       {
         "type": "gdb",
         "label": "GDB",
-        "program": "./dist/debugAdapter.js",
+        "program": "./node_modules/cdt-gdb-adapter/dist/debugAdapter.js",
         "runtime": "node",
         "configurationAttributes": {
           "launch": {
@@ -228,7 +228,7 @@
       {
         "type": "gdbtarget",
         "label": "GDB Target",
-        "program": "./dist/debugTargetAdapter.js",
+        "program": "./node_modules/cdt-gdb-adapter/dist/debugTargetAdapter.js",
         "runtime": "node",
         "configurationAttributes": {
           "launch": {
@@ -726,10 +726,8 @@
     "watch:tsc": "tsc -b -w",
     "build:esbuild": "node esbuild.js",
     "watch:esbuild": "node esbuild.js --watch",
-    "build": "run-s build:*",
-    "pre-watch": "yarn build",
-    "do-watch": "run-p watch:*",
-    "watch": "run-s pre-watch do-watch",
+    "build": "run-p build:*",
+    "watch": "run-p watch:*",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
     "format-check": "prettier --check .",

--- a/src/memory/client/MemoryBrowser.tsx
+++ b/src/memory/client/MemoryBrowser.tsx
@@ -15,7 +15,7 @@
 import * as React from 'react';
 import { MemoryContents } from 'cdt-gdb-adapter';
 
-import '../../../src/memory/client/MemoryBrowser.scss';
+import './MemoryBrowser.scss';
 import { messageBroker } from './MessageBroker';
 
 class ForwardIterator implements Iterator<number> {

--- a/src/memory/client/tsconfig.json
+++ b/src/memory/client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "outDir": "../../../out/memory",
+    "outDir": "../../../dist/memory",
     "rootDir": "../",
     "esModuleInterop": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2015",
-    "outDir": "out",
+    "outDir": "dist",
     "lib": ["es2015", "dom"],
     "jsx": "react",
     "strict": true,


### PR DESCRIPTION
This PR reduces the effects of #96 to the following:
 - Replaces Webpack with ESBuild (but only use it on the webview code, as before #96)
 - Move the output directory to `dist` rather than `out`. This is so that any adjustments made since #96 continue to apply. It would easy to move back to `out` if that is preferred.

In particular:
 - We go back to relying on `vsce`'s resolution of runtime depndencies to keep all of the node modules that are relevant at runtime.
 - We use `tsc` to transpile into the `dist` folder, with `.d.ts` files in the expected 1:1 relationship with transpiled `.js` files.

Functionally, bundling worked fine for three of the four things to which it was applied, the extension code: the webview code, and the CDT-GDB Adapter's `debugAdapter` entry point. It failed for `targetDebugAdapter` because it depends on a package that depends on a package that requires specific file structure layout. Bundling the extension and the `debugAdapter` would bring some performance benefits, but they would be fairly negligible.

## To Test
1. Build the plugin.
2. Run the plugin and execute a debug session with a remote target.
3. Run `vsce ls` and confirm that the kitchen sink is back (but that nothing from the `dist` folder we don't want has crept in).

Fixes #111