### PR TITLE
Prepare for v0.0.108

### DIFF
--- a/package.json
+++ b/package.json
@@ -737,7 +737,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^0.0.31",
+    "cdt-gdb-adapter": "^0.0.32",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "0.0.107",
+  "version": "0.0.108",
   "description": "VS Code extension for CDT GDB debug adapter",
   "publisher": "eclipse-cdt",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,10 +604,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.31.tgz#d9f73baa7775401c7d371cb53906cca2749f8774"
-  integrity sha512-mgoh8sGwJhaFlO+5USiFjgoW84C2IlDiojaDKIBmt0Jn6EbcAU6edOk/KYFRH+NoeeWthP52P9QQq/V3S5cgzw==
+cdt-gdb-adapter@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.32.tgz#46a52f9867dd4da4b65161a7f54c82586035953e"
+  integrity sha512-BDR0AwvdZ2qBuiJbk3C0yKqEBIfm5BlODsQDHlu1+YhH3JxLrBsX0p5GHZakUfwVME0xl92QU3+vFxoQAHw4DA==
   dependencies:
     "@vscode/debugadapter" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"


### PR DESCRIPTION
Update to adapter 0.0.32 (bug fixes, stepping granularity)

Adds support for these features/bug fixes in the adapter:

- A fix the newline handling for the UART
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/318
- New feature of supporting stepping granularity
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/309