### PR TITLE
Add definitionPath property to debug configuration attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,11 @@
                 },
                 "default": []
               },
+              "definitionPath": {
+                "type": "string",
+                "description": "Setting for 'PERIPHERALS' window provided by 'eclipse-cdt.peripheral-inspector'. It can be a simple file name or based on a CMSIS pack or deviceName. See 'eclipse-cdt.peripheral-inspector' for format",
+                "default": null
+              },
               "imageAndSymbols": {
                 "type": "object",
                 "default": {},
@@ -540,6 +545,11 @@
                   "type": "string"
                 },
                 "default": []
+              },
+              "definitionPath": {
+                "type": "string",
+                "description": "Setting for 'PERIPHERALS' window provided by 'eclipse-cdt.peripheral-inspector'. It can be a simple file name or based on a CMSIS pack or deviceName. See 'eclipse-cdt.peripheral-inspector' for format",
+                "default": null
               },
               "imageAndSymbols": {
                 "type": "object",


### PR DESCRIPTION
This PR adds the property 'definitionPath' to the attributes of the 'gdbtarget' debug configuration. This property comes from the peripheral-inspector extension.
Adding this property promotes the use of the eclipse-cdt.peripheral-inspector extension and avoids the yellow squiggly line in the launch.json file.