### PR TITLE
Enhancing ImageAndSymbols to load several binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,25 +304,47 @@
                 "type": "object",
                 "default": {},
                 "properties": {
-                  "symbolFileName": {
-                    "type": "string",
-                    "description": "If specified, a symbol file to load at the given (optional) offset",
-                    "default": ""
+                  "symbolFilesAndOffset": {
+                    "type": "array",
+                    "description": "If specified, list of symbol files to load at the given (optional) offset",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "type": "string",
+                          "description": "If specified, a symbol file to load at the given (optional) offset",
+                          "default": ""
+                        },
+                        "offset": {
+                          "type": "string",
+                          "description": "If symbol file is specified, the offset used to load (optional)",
+                          "default": ""
+                        }
+                      },
+                      "default": {}
+                    },
+                    "default": []
                   },
-                  "symbolOffset": {
-                    "type": "string",
-                    "description": "If symbolFileName is specified, the offset used to load",
-                    "default": ""
-                  },
-                  "imageFileName": {
-                    "type": "string",
-                    "description": "If specified, an image file to load at the given (optional) offset",
-                    "default": ""
-                  },
-                  "imageOffset": {
-                    "type": "string",
-                    "description": "If imageFileName is specified, the offset used to load",
-                    "default": ""
+                  "imageFilesAndOffset": {
+                    "type": "array",
+                    "description": "If specified, list of image files to load at the given (optional) offset",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "type": "string",
+                          "description": "If specified, an image file to load at the given (optional) offset",
+                          "default": ""
+                        },
+                        "offset": {
+                          "type": "string",
+                          "description": "If image file is specified, the offset used to load (optional)",
+                          "default": ""
+                        }
+                      },
+                      "default": {}
+                    },
+                    "default": []
                   }
                 }
               },
@@ -545,25 +567,47 @@
                 "type": "object",
                 "default": {},
                 "properties": {
-                  "symbolFileName": {
-                    "type": "string",
-                    "description": "If specified, a symbol file to load at the given (optional) offset",
-                    "default": ""
+                  "symbolFilesAndOffset": {
+                    "type": "array",
+                    "description": "If specified, list of symbol files to load at the given (optional) offset",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "type": "string",
+                          "description": "If specified, a symbol file to load at the given (optional) offset",
+                          "default": ""
+                        },
+                        "offset": {
+                          "type": "string",
+                          "description": "If symbol file is specified, the offset used to load (optional)",
+                          "default": ""
+                        }
+                      },
+                      "default": {}
+                    },
+                    "default": []
                   },
-                  "symbolOffset": {
-                    "type": "string",
-                    "description": "If symbolFileName is specified, the offset used to load",
-                    "default": ""
-                  },
-                  "imageFileName": {
-                    "type": "string",
-                    "description": "If specified, an image file to load at the given (optional) offset",
-                    "default": ""
-                  },
-                  "imageOffset": {
-                    "type": "string",
-                    "description": "If imageFileName is specified, the offset used to load",
-                    "default": ""
+                  "imageFilesAndOffset": {
+                    "type": "array",
+                    "description": "If specified, list of image files to load at the given (optional) offset",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "type": "string",
+                          "description": "If specified, an image file to load at the given (optional) offset",
+                          "default": ""
+                        },
+                        "offset": {
+                          "type": "string",
+                          "description": "If image file is specified, the offset used to load (optional)",
+                          "default": ""
+                        }
+                      },
+                      "default": {}
+                    },
+                    "default": []
                   }
                 }
               },


### PR DESCRIPTION
Currently, the "imageAndSymbols" option can be used to load one additional file. To load multiple files you can manually load them via the "initCommands" option.
This PR enhances the ImageAndSymbols property to manage this use case.
A PR will also be submitted in the repository cdt-gdb-adapter to implement this enhancement.