### PR TITLE
Update to adapter 1.0.1 (web extension support and other improvements)

### DIFF
--- a/package.json
+++ b/package.json
@@ -737,7 +737,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^0.0.32",
+    "cdt-gdb-adapter": "^1.0.1-next.20240911234240.8957e37.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,10 +604,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^0.0.32:
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.32.tgz#46a52f9867dd4da4b65161a7f54c82586035953e"
-  integrity sha512-BDR0AwvdZ2qBuiJbk3C0yKqEBIfm5BlODsQDHlu1+YhH3JxLrBsX0p5GHZakUfwVME0xl92QU3+vFxoQAHw4DA==
+cdt-gdb-adapter@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.1.tgz#f950ecf3eed6baf9c907a3208a0b6f26e9cb1415"
+  integrity sha512-HUcVayhO1fcuZXhUR44o9xvOhqkbi4HvkkL3AlIii9N6R2YwvpgRRPEEu/8rcYMz2VQ6qHWzr1yK+qEK2L+oXQ==
   dependencies:
     "@vscode/debugadapter" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"


### PR DESCRIPTION
Includes:

- Refactor code to allow web extension
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/328
- Improved handling of ContinuedEvent
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/335
- Ensure 'interrupt' and 'disconnect' signals are sent before '-gdb-exit'
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/338
- Add API to pause target and wait for debugger to be suspended
  - https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/339