### PR TITLE
Remove "files" from package.json as it conflicts with ".vscodeignore"

### DIFF
--- a/package.json
+++ b/package.json
@@ -762,14 +762,5 @@
   },
   "bundledDependencies": [
     "cdt-gdb-adapter"
-  ],
-  "files": [
-    "NOTICE",
-    "LICENSE",
-    "README.md",
-    "CONTRIBUTING.md",
-    "dist/**/*.js",
-    "dist/**/*.js.map",
-    "dist/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
This resolves build issue:

    Error: Both a .vscodeignore file and a "files" property
    in package.json were found. VSCE does not support combining
    both strategies. Either remove the .vscodeignore file or the
    "files" property in package.json.

Fixes #125