### PR TITLE
Update to Node 20 and prettier fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Build
         run: |
           yarn install --ignore-scripts
@@ -61,7 +61,7 @@ jobs:
           path: artifacts
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Publish
         run: |
           npx ovsx publish -i artifacts/*/*.vsix -p ${{secrets.OPEN_VSX_TOKEN}}
@@ -78,7 +78,7 @@ jobs:
           path: artifacts
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Publish
         run: |
           npx vsce publish -i artifacts/*/*.vsix -p ${{secrets.VS_MARKETPLACE_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -745,7 +745,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.4",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^14.18.17",
+    "@types/node": "~20.14.15",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@types/vscode": "^1.78.0",

--- a/package.json
+++ b/package.json
@@ -756,6 +756,7 @@
     "esbuild": "^0.19.2",
     "esbuild-sass-plugin": "^2.13.0",
     "eslint": "^8.35.0",
+    "eslint-config-prettier": "^8.6.0",
     "event-stream": "^4.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "2.8.4",

--- a/src/memory/client/MemoryBrowser.tsx
+++ b/src/memory/client/MemoryBrowser.tsx
@@ -84,7 +84,7 @@ export class MemoryBrowser extends React.Component<Props, State> {
   private addressReq = '';
   private lengthReq = '512';
   private childReq = 0;
-  public static firstTime: boolean = true;
+  public static firstTime = true;
 
   constructor(props: Props) {
     super(props);
@@ -356,7 +356,7 @@ export class MemoryBrowser extends React.Component<Props, State> {
       MemoryBrowser.firstTime = false;
     }
     const { childrenNames } = this.state;
-    let childrenNamesList =
+    const childrenNamesList =
       childrenNames.length > 0 &&
       childrenNames.map((item, i) => {
         return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@^8.6.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz#3a06a662130807e2502fc3ff8b4143d8a0658e11"
+  integrity sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,12 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
-"@types/node@^14.18.17":
-  version "14.18.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.37.tgz#0bfcd173e8e1e328337473a8317e37b3b14fd30d"
-  integrity sha512-7GgtHCs/QZrBrDzgIJnQtuSvhFSwhyYSI2uafSwZoNt1iOGhEN5fwNrQMjtONyHm9+/LoA4453jH0CMYcr06Pg==
+"@types/node@~20.14.15":
+  version "20.14.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.15.tgz#e59477ab7bc7db1f80c85540bfd192a0becc588b"
+  integrity sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -3071,6 +3073,11 @@ underscore@^1.12.1:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Follow up to #130 , related to #119 :

This PR
* Updates Node to version 20 for CI. Required by latest `vsce` version, and unblocks version bumps for other dependencies.
* Fixes `lint` script which was broken due to missing dev dependency `eslint-config-prettier` to integrate `prettier` with `eslint`.
* Fixes two minor issues found by linter. Linter not activated in CI yet.

The CI build step should now complete.