### PR TITLE
v2.0.0 preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.1.0
+## 2.0.0
 - First release to the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode) in addition to existing releases to the [Open VSX Registry](https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode).
 - Updated extension logo.
 - Updated user and repository documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
-## Unreleased
+## 1.1.0
 - First release to the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.cdt-gdb-vscode) in addition to existing releases to the [Open VSX Registry](https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode).
 - Updated extension logo.
 - Updated user and repository documentation.
-- Updated extension dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the CDT GDB Debug Adapter Extension for Visual Studio Code
 
-Thanks for your interest in this project, part of the [Eclipse C/C++ Development Tools project](https://projects.eclipse.org/projects/tools.cdt)
+Thanks for your interest in this project, part of [Eclipse CDT Cloud](https://eclipse.dev/cdt-cloud/).
 
 The source code can be found in the following repository: https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the CDT GDB Debug Adapter Extension for Visual Studio Code
+# Contributing to the CDT GDB Debug Adapter Extension for Visual Studio Code
 
 Thanks for your interest in this project, part of the [Eclipse C/C++ Development Tools project](https://projects.eclipse.org/projects/tools.cdt)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to VS Code Debug Extension for GDB
+# Contributing the CDT GDB Debug Adapter Extension for Visual Studio Code
 
 Thanks for your interest in this project, part of the [Eclipse C/C++ Development Tools project](https://projects.eclipse.org/projects/tools.cdt)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Developing the VS Code Debug Extension for GDB
+# Developing the CDT GDB Debug Adapter Extension for Visual Studio Code
 
 This document provides instructions and hints for how to build and develop this extension. More information on contributions to this project can be found in the [contribution guidelines](/CONTRIBUTING.md).
 
@@ -37,7 +37,7 @@ yarn link cdt-gdb-adapter
 
 You can set up a VS Code workspace that has both folders. Also make sure you have builds running in each folder to pick up updates (e.g. `yarn watch`).
 
-The way to debug cdt-gdb-adapter works with the same principle as the example Mock Debug Adapter provided by VSCode.
+The way to debug cdt-gdb-adapter works with the same principle as the example Mock Debug Adapter provided by VS Code.
 For detailed instructions please refer to [Development Setup for Mock Debug](https://code.visualstudio.com/api/extension-guides/debugger-extension#development-setup-for-mock-debug).
 
 The short step-by-step version is:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # CDT GDB Debug Adapter Extension for Visual Studio Code
 
-> Note: This is a preliminary milestone release. Please help us by trying out this extension and providing feedback using [our github issues page](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues).
-
 This is a Visual Studio Code extension that supports debugging using gdb and any other debugger that supports the MI protocol. It is built by the experts that provide the gdb support in the Eclipse C/C++ IDE (CDT).
 
 This extension provides a number of features that integrate into the Visual Studio Code debug environment. This includes launch types, support for the standard debug views as well as a custom viewer for memory browsing.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VS Code Debug Extension for GDB
+# CDT GDB Debug Adapter Extension for Visual Studio Code
 
 > Note: This is a preliminary milestone release. Please help us by trying out this extension and providing feedback using [our github issues page](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "cdt-gdb-vscode",
   "version": "1.0.4",
-  "description": "VS Code extension for CDT GDB debug adapter",
+  "displayName": "CDT GDB Debug Adapter Extension",
+  "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",
   "repository": {
     "type": "git",
@@ -18,6 +19,13 @@
   "engines": {
     "vscode": "^1.78.0"
   },
+  "categories": [
+    "Debuggers"
+  ],
+  "keywords": [
+    "debug",
+    "GDB"
+  ],
   "activationEvents": [
     "onDebug",
     "onCommand:cdt.gdb.memory.open",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",


### PR DESCRIPTION
Addresses #136 (see issue for rational why not updating more dependencies first).
Should be merged after #135.

**_Note that this contains some potentially controversial changes concerning the extension's name._**

Preparations for first release to both VS Code marketplace and Open VSX registry.
- Targets ~v1.1.0~ v2.0.0.
- Updates version in `CHANGELOG.md` and `package.json`.
- Adds some missing/useful fields to the extension manifest. This includes `displayName` which is shown on the marketplace and presumably Open VSX instead of `cdt-gdb-vscode`.
  - Set `displayName` to "CDT GDB Debug Adapter Extension"
  - Changed `description` to "CDT GDB debug adapter extension for Visual Studio Code" to better agree with VS Code [brand guidelines](https://code.visualstudio.com/brand).
  - Updated `README.md`, `DEVELOPMENT.md`, and `CONTRIBUTING.md` titles (in the files) accordingly.

Adding `displayName` and changing description and MD title names (in the files) is the potentially controversial part:
- The extension will show now with a different name in Open VSX. And after installation in VS Code.
- This could be a reason for a major version change, i.e. to v2.0.0. But I believe removal of the Memory Browser would be the next major version update due to removal of a feature. Maybe not an issue at all to have two major version increments in short time (if the removal happens soon).

[Update]: Changed to prepare for v2.0.0, no longer v1.1.0.

@jonahgraham , @thegecko , opinions on this would be much appreciated.