### PR TITLE
Update to cdt-gdb-adapter v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.0.2
+- Update to cdt-gdb-adapter v1.0.6
+  - [Hardware/Software Breakpoint Modes](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/350)
+  - [Fixes step out to always step out of top frame](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/353)
+
 ## 2.0.1
 - Update to cdt-gdb-adapter v1.0.4
   - [Add supportsEvaluateForHovers](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/347)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",
@@ -746,7 +746,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^1.0.4",
+    "cdt-gdb-adapter": "^1.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.4.tgz#f1d9d5a2479e536007bec24f9d66e03806f5c0e7"
-  integrity sha512-oABX1bY7HArgqONq/Sf8Gltku3glpj/93TfF4zP6jULWJNZGZ3F0AH+HB8TpXFYFRFQc1101xrf0WHcipeMtdg==
+cdt-gdb-adapter@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.6.tgz#1dac4ff4cb5836f157481f523c1e7ea133a096f0"
+  integrity sha512-XUL7RRWlngHno9MkB43/sO+Q3wygkf6Wv70YhAw26D+SGAiGpa7fpARdnonQHVfBHQD2TAG7dePb0t5nmA6LvQ==
   dependencies:
     "@vscode/debugadapter" "^1.68.0"
     "@vscode/debugprotocol" "^1.68.0"


### PR DESCRIPTION
 - [Hardware/Software Breakpoint Modes](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/350)
 - [Fixes step out to always step out of top frame](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/353)