### PR TITLE
#144: CI - do not ignore scripts for yarn install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20.x
       - name: Build
         run: |
-          yarn install --ignore-scripts
+          yarn install
           yarn build
           yarn vsce:package
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2.0.3
+- Fixes [#144](Error with the openGdbConsole option)
+
 ## 2.0.2
 - Update to cdt-gdb-adapter v1.0.6
   - [Hardware/Software Breakpoint Modes](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/350)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",


### PR DESCRIPTION
Addresses #144  - fix to be confirmed

Remove ` --ignore-scripts` during `yarn install` in CI.
Required to build dependencies, in particular `nativebuild` script of `cdt-gdb-adapter`.