### PR TITLE
Adding a custom event to trigger re-rendering of breakpoints in source code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,6 @@ export { ResumeAllSession } from './ResumeAllSession';
 import { SuspendAllSession } from './SuspendAllSession';
 export { SuspendAllSession } from './SuspendAllSession';
 
-
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);
     new ResumeAllSession(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import { ExtensionContext, commands, window } from 'vscode';
+import { ExtensionContext, commands, window, debug } from 'vscode';
 import { MemoryServer } from './memory/server/MemoryServer';
 export { MemoryServer } from './memory/server/MemoryServer';
 import { ResumeAllSession } from './ResumeAllSession';
@@ -15,10 +15,19 @@ export { ResumeAllSession } from './ResumeAllSession';
 import { SuspendAllSession } from './SuspendAllSession';
 export { SuspendAllSession } from './SuspendAllSession';
 
+
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);
     new ResumeAllSession(context);
     new SuspendAllSession(context);
+
+    debug.onDidReceiveDebugSessionCustomEvent(event => {
+        if (event.event === "UpdateBreakpointView") {
+          const bps = debug.breakpoints;
+          debug.removeBreakpoints(bps);
+          debug.addBreakpoints(bps);
+        }
+      });
 
     context.subscriptions.push(
         commands.registerCommand('cdt.debug.askProgramPath', (_config) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: ExtensionContext) {
     new SuspendAllSession(context);
 
     debug.onDidReceiveDebugSessionCustomEvent(event => {
-        if (event.event === "UpdateBreakpointView") {
+        if (event.event === "cdt-gdb-adapter/UpdateBreakpointView") {
           const bps = debug.breakpoints;
           debug.removeBreakpoints(bps);
           debug.addBreakpoints(bps);


### PR DESCRIPTION
Hello,

I added a custom event for triggering a re-render of breakpoints in source code, because just sending a breakpoint event from the adapter to the extension was not enough

Please see
https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/368