### PR TITLE
v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.5
+- Update to cdt-gdb-adapter v1.0.9
+  - [Support GDB/MI breakpoint notifications](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/360)
+
 ## 2.0.4
 - Update to cdt-gdb-adapter v1.0.8
   - [Optional device reset during debug session](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/359)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 2.0.5
-- Update to cdt-gdb-adapter v1.0.9
+- Update to cdt-gdb-adapter v1.0.10
   - [Support GDB/MI breakpoint notifications](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/360)
 
 ## 2.0.4

--- a/package.json
+++ b/package.json
@@ -775,7 +775,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^1.0.9",
+    "cdt-gdb-adapter": "^1.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -775,7 +775,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^1.0.8",
+    "cdt-gdb-adapter": "^1.0.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.8.tgz#6c8271f76bcdaed8b55347501c957aa4062ee1a6"
-  integrity sha512-A7/0QJAUjCcrUZ5A54aVFOuUtEH273EmbOfyvJhHZzMJEWM1899MVkohrfM4nGEqbUzSrvHoQW3a44I5DykoIA==
+cdt-gdb-adapter@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.9.tgz#b6efcf9a10fc576b3837c636b720b2b722591889"
+  integrity sha512-ZQedkRWMzxmxRnodqOZ+yfRVU3IL9EouJFp+yCzKFoq27l9R7lGlU8/Gu4AkK8iy39Obsoc7vN8XXB0euK8PJw==
   dependencies:
     "@vscode/debugadapter" "^1.68.0"
     "@vscode/debugprotocol" "^1.68.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.9.tgz#b6efcf9a10fc576b3837c636b720b2b722591889"
-  integrity sha512-ZQedkRWMzxmxRnodqOZ+yfRVU3IL9EouJFp+yCzKFoq27l9R7lGlU8/Gu4AkK8iy39Obsoc7vN8XXB0euK8PJw==
+cdt-gdb-adapter@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.0.10.tgz#5e81a5e393610140314950cf2b888dcd90e6c1f3"
+  integrity sha512-NS2yL6Bs8sJ1M043hACuc4nMM5jEaqIjv1xtajiCaFVLpyGbY7GzqR+baH6Gk9nkxkxeGrL+Ep82KL5nqMUEEw==
   dependencies:
     "@vscode/debugadapter" "^1.68.0"
     "@vscode/debugprotocol" "^1.68.0"


### PR DESCRIPTION
- Update cdt-gdb-adapter to v1.0.10
- Release preparations: v2.0.5

Notes:
* No effective change since last release on this repo.
* Skipping v1.0.9 which was an improvement but would have introduced usability issues with a new feature.