### PR TITLE
removed unneeded custom bp event

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,11 +14,14 @@ import { ResumeAllSession } from './ResumeAllSession';
 export { ResumeAllSession } from './ResumeAllSession';
 import { SuspendAllSession } from './SuspendAllSession';
 export { SuspendAllSession } from './SuspendAllSession';
+import { CustomReset } from './CustomReset';
+export { CustomReset } from './CustomReset';
 
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);
     new ResumeAllSession(context);
     new SuspendAllSession(context);
+    new CustomReset(context);
 
     context.subscriptions.push(
         commands.registerCommand('cdt.debug.askProgramPath', (_config) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,29 +7,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import { ExtensionContext, commands, window, debug } from 'vscode';
+import { ExtensionContext, commands, window } from 'vscode';
 import { MemoryServer } from './memory/server/MemoryServer';
 export { MemoryServer } from './memory/server/MemoryServer';
 import { ResumeAllSession } from './ResumeAllSession';
 export { ResumeAllSession } from './ResumeAllSession';
 import { SuspendAllSession } from './SuspendAllSession';
 export { SuspendAllSession } from './SuspendAllSession';
-import { CustomReset } from './CustomReset';
-export { CustomReset } from './CustomReset';
 
 export function activate(context: ExtensionContext) {
     new MemoryServer(context);
     new ResumeAllSession(context);
     new SuspendAllSession(context);
-    new CustomReset(context);
-
-    debug.onDidReceiveDebugSessionCustomEvent(event => {
-        if (event.event === "cdt-gdb-adapter/UpdateBreakpointView") {
-          const bps = debug.breakpoints;
-          debug.removeBreakpoints(bps);
-          debug.addBreakpoints(bps);
-        }
-      });
 
     context.subscriptions.push(
         commands.registerCommand('cdt.debug.askProgramPath', (_config) => {


### PR DESCRIPTION
The custom event that was created for the sake of toggling all breakpoints for rendering them is no longer needed

For more info, check out https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/360