### PR TITLE
Adding language array for package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixes [#161](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/161): Changed "Custom Reset" button tooltip to "Reset Target" 
 - Update to cdt-gdb-adapter v1.0.11
   - [Adds instruction breakpoint support to enable breakpoints in Disassembly View](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/373)
+- Showing Open Disassembly View option in source view's context menu [#95](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/95)
 
 ## 2.0.5
 - Update to cdt-gdb-adapter v1.0.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Change Log
 
+# Unreleased
+- Showing Open Disassembly View option in source view's context menu [#95](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/95)
+
 ## 2.0.6
 - Fixes [#161](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/161): Changed "Custom Reset" button tooltip to "Reset Target" 
 - Update to cdt-gdb-adapter v1.0.11
   - [Adds instruction breakpoint support to enable breakpoints in Disassembly View](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/373)
-- Showing Open Disassembly View option in source view's context menu [#95](https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/95)
 
 ## 2.0.5
 - Update to cdt-gdb-adapter v1.0.10

--- a/package.json
+++ b/package.json
@@ -248,6 +248,10 @@
       {
         "type": "gdbtarget",
         "label": "GDB Target",
+        "languages": [
+          "c",
+          "cpp"
+        ],
         "program": "./node_modules/cdt-gdb-adapter/dist/debugTargetAdapter.js",
         "runtime": "node",
         "configurationAttributes": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
       {
         "type": "gdb",
         "label": "GDB",
+        "languages": [
+          "c",
+          "cpp"
+        ],
         "program": "./node_modules/cdt-gdb-adapter/dist/debugAdapter.js",
         "runtime": "node",
         "configurationAttributes": {


### PR DESCRIPTION
I added the language array for the package.json as it is needed for making the `Open Disassembly View` command visible in the context menu of the source window.

Please check this issue for reference 
https://github.com/microsoft/vscode/issues/165872