### PR TITLE
v2.2.0 Release Preparations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # Change Log
 
-# Unreleased
+## 2.2.0
 
--  Fixes [#398](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/398): Give gdbserver time to gracefully disconnect before terminating it
+- Fixes [`#173`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/173): Add `target`>`watchServerProcess` setting to ignore early exit of `server` executable, e.g. if a launcher for actual gdbserver.
+- Fixes [cdt-gdb-adapter`#367`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/367): Allow empty `program` setting for remote `launch`/`attach` and for local `attach` configurations.
+- Fixes [cdt-gdb-adapter`#398`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/398): Add `target`>`serverDisconnectTimeout` setting to configure timeout for graceful gdbserver disconnect.
+- Update to cdt-gdb-adapter v1.2.0
+    - Fixes [`#173`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/173): Add `target`>`watchServerProcess` setting to ignore early exit of `server` executable, e.g. if a launcher for actual gdbserver.
+    - Fixes [cdt-gdb-adapter `#330`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/330) / [`#151`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/151): Cannot remove breakpoint when debugging (Windows, Theia).
+    - Fixes [cdt-gdb-adapter`#362`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/362): Cannot execute CLI commands like `> interrupt` from Debug Console while CPU is running.  
+      **Note**: Depends on whether a blocking command was executed from CLI before.
+    - Fixes [cdt-gdb-adapter`#367`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/367): Debugging with `gdbtarget` fails if `program` is omitted, despite user doc claiming it's optional.
+    - Fixes [cdt-gdb-adapter`#398`](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/398): Give gdbserver time to gracefully disconnect before terminating it.
+    - Enhancement: Improve error message if setting more HW breakpoints than supported by target.
+    - Enhancement: Improve error message on `-target-select` timeout on Windows.
 
-# 2.1.0
+## 2.1.0
 
-- Adds [PR #168](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/168): Supported languages for `gdb` and `gdbtarget` debug adapter types to show `Open Disassembly View` context menu entry in source code editors.
-- Implements [#157](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/157): Update NPM dependencies, Node and Python requirements, and Typescript version.
+- Adds [PR `#168`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/pull/168): Supported languages for `gdb` and `gdbtarget` debug adapter types to show `Open Disassembly View` context menu entry in source code editors.
+- Implements [`#157`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/157): Update NPM dependencies, Node and Python requirements, and Typescript version.
 - Update to cdt-gdb-adapter v1.1.0
     - [Fixes and robustness around remote target GDB connect, disconnect, and unexpected connection loss/termination of gdb and gdbserver.](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/361)
     - [Error handling for missing remote configuration like port.](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/pull/384)
@@ -15,7 +26,7 @@
 
 ## 2.0.6
 
-- Fixes [#161](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/161): Changed "Custom Reset" button tooltip to "Reset Target"
+- Fixes [`#161`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/161): Changed "Custom Reset" button tooltip to "Reset Target"
 - Update to cdt-gdb-adapter v1.0.11
     - [Adds instruction breakpoint support to enable breakpoints in Disassembly View](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/373)
 
@@ -32,7 +43,7 @@
 
 ## 2.0.3
 
-- Fixes [#144](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/144): Error with the openGdbConsole option
+- Fixes [`#144`](https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/144): Error with the openGdbConsole option
 
 ## 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Additional settings to configure the remote GDB target. This object can be used 
 | `serverDisconnectTimeout` | x | | `number` |Timeout for GDB server disconnect request. Default value is 1000 (ms). |
 | `serverStartupDelay` | x | | `number` | Delay, in milliseconds, after startup but before continuing launch. If `serverPortRegExp` is provided, it is the delay after that regexp is seen. |
 | `automaticallyKillServer` | x | | `boolean` | Automatically terminate the launched server when client issues a disconnect.<br>Default: `true` |
+| `watchServerProcess` | x | | `boolean` | Watch server process and handle when it (unexpectedly) exits.<br>Default: `true` |
 | `uart` | x | x | `object` | Settings related to displaying UART output in the debug console. |
 
 ##### `uart` object

--- a/package.json
+++ b/package.json
@@ -791,7 +791,7 @@
   },
   "dependencies": {
     "cdt-amalgamator": "^0.0.11",
-    "cdt-gdb-adapter": "^1.1.0",
+    "cdt-gdb-adapter": "^1.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdt-gdb-vscode",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "displayName": "CDT GDB Debug Adapter Extension",
   "description": "CDT GDB debug adapter extension for Visual Studio Code",
   "publisher": "eclipse-cdt",

--- a/package.json
+++ b/package.json
@@ -434,6 +434,11 @@
                     "description": "Timeout for GDB server disconnect request. Default value is 1000 (ms).",
                     "default": 1000
                   },
+                  "watchServerProcess": {
+                    "type": "boolean",
+                    "description": "Watch server process and handle when it (unexpectedly) exits (default: true)",
+                    "default": true
+                  },
                   "uart": {
                     "type": "object",
                     "description": "Settings related to displaying UART output in the debug console",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,10 +1203,10 @@ cdt-amalgamator@^0.0.11:
     "@vscode/debugadapter-testsupport" "^1.59.0"
     "@vscode/debugprotocol" "^1.59.0"
 
-cdt-gdb-adapter@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.1.0.tgz#7022c4966f4d1dfb6b944041855e35e3458a957d"
-  integrity sha512-okhtRa92i3qoAF7Jrqa3V/XsXXEFwHtNnMEaMhmT6xz0NeZMJ+HH0aqeJaKrbn3syY1kLyqtGnoCiPw70Rp2VA==
+cdt-gdb-adapter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-1.2.0.tgz#1e6ff7fff9b59ed3c6ae494ce13ab076890190e8"
+  integrity sha512-9rL8rnkO6IGJGRDMS303AqJ3kfIma9jpyjarKGrqHRVi14oXwsVsEa8sfPKTFyc39q797gy76l4ZoCgqi9ug/Q==
   dependencies:
     "@vscode/debugadapter" "^1.68.0"
     "@vscode/debugprotocol" "^1.68.0"


### PR DESCRIPTION
* Bump extension version to v2.2.0
* Bump included cdt-gdb-adapter to v1.2.0
* Update CHANGELOG for release
* Updates CHANGELOG links to put GH PR/Issue references into backticks. Attempt to deal with OpenVSX/VS Code marketplace CHANGELOG rendering which gets messy if using the #<n> notation for links to other repos.
* Adds new `watchServerProcess` setting to debugger contribution and docs.