### PR TITLE
Clarify `initCommands` for gdbtarget

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Launch and attach configuration settings that can be used with the `gdbtarget` d
 | `verbose` | x | x | `boolean` | Produce verbose log output. |
 | `logFile` | x | x | `string` | Absolute path to the file to log interaction with GDB.|
 | `openGdbConsole` | x | x | `boolean` | *(UNIX-only)* Open a GDB console in your IDE while debugging. |
-| `initCommands` | x | x | `string[]` | List of GDB commands sent before attaching to inferior. |
+| `initCommands` | x | x | `string[]` | List of GDB commands sent to initialize debug target after attaching to it but before loading image and symbols. |
 | `preRunCommands` | x | x | `string[]` | List of GDB commands sent after loading image on target before resuming target. |
 | `imageAndSymbols` | x | x | `object` | Additional settings for loading images to the target and symbols into the debugger. See section "`imageAndSymbols` object" for details.
 | `target` | x | x |  `object` | Additional settings to configure the remote GDB target. See section "`target` object" for details. |


### PR DESCRIPTION
Related to https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/issues/432
* Clarifies purpose of `initCommands` setting for gdbtarget type. Behavior is different from `gdb` type in that they get executed after target connection but before loading and running the program.